### PR TITLE
A near rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 [![codecov.io](http://codecov.io/github/JuliaArrays/ShowItLikeYouBuildIt.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaArrays/ShowItLikeYouBuildIt.jl?branch=master)
 
-ShowItLikeYouBuildIt is designed to simplify the printing of certain
-types in Julia. Specifically, this package currently provides tools
-for simplifying the `summary` of arrays.
+ShowItLikeYouBuildIt is designed to simplify the printing of type
+information (in certain contexts) in Julia. Specifically, this package
+currently provides tools for simplifying the `summary` of arrays.
 
 # Example of usage
 
 Currently, the printing of a simple array looks like this:
+
 ```jl
 julia> a = reshape(1:12, 3, 4)
 3×4 Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}:
@@ -18,29 +19,38 @@ julia> a = reshape(1:12, 3, 4)
  2  5  8  11
  3  6  9  12
 ```
-It's worth noting that printing of the type information is both longer and more complex than the sequence of commands needed to construct the object.
 
-The idea of this package is that it might simplify the type
-information if one instead showed a sequence of function calls that
-would create an identical type. First, we have to specialize the
-`showtypeof` function for our array type:
+It's worth noting that printing of the type information in the first
+line---produced by the Base function `summary`---is both longer and
+more complex than the sequence of commands needed to construct the
+object.
+
+The idea of this package is to simplify the type information by
+instead showing a sequence of function calls that would create an
+identical type. To implement this for your own `AbstractArray` type,
+the first step is to specialize the `showarg` function (which shows an
+object `x` as if it were an argument to a function) for your array
+type:
 
 ```jl
-function ShowItLikeYouBuildIt.showtypeof(io::IO, A::Base.ReshapedArray)
-    P = parent(A)
+function ShowItLikeYouBuildIt.showarg(io::IO, A::Base.ReshapedArray)
     print(io, "reshape(")
-    if ShowItLikeYouBuildIt.shows_compactly(typeof(P))
-        print(io, "::", typeof(P))
-    else
-        ShowItLikeYouBuildIt.showtypeof(io, P)
-    end
+    showarg(io, parent(A))
     print(io, ", ", A.dims, ')')
 end
 ```
-and then we hook this up to the `summary` function:
+
+Next, we hook this up so that it gets called by Base's `summary` function:
+
 ```jl
-Base.summary(A::Base.ReshapedArray) = summary_compact(A)
+Base.summary(A::Base.ReshapedArray) = summary_build(A)
 ```
+
+`summary_build` is a simple function that prints the dimension string,
+calls `showarg` on `A`, and then prints the element type. If you
+wanted, you could customize `summary` differently from this; as long
+as your method calls `showarg` on `A`, the machinery we've defined
+will be actived.
 
 Now the printing of this array looks like this:
 ```jl
@@ -52,4 +62,49 @@ julia> a = reshape(1:12, 3, 4)
 ```
 
 The noteworthy thing here is that we're displaying the type via a set
-of function calls that would produce an object with this type.
+of function calls that would produce an object with this type. The
+printing of the "inner" array as `::UnitRange{Int64}` is the default
+behavior of `showarg`, printing information about the object in terms
+of its type (as an argument to a function, not as a type-parameter,
+hence the `::`).
+
+In general, `showarg` methods for `AbstractArray` types that wrap
+other arrays should call `showarg` on at least the "main" array in the
+container. This allows the summary of a type to be printed as a nested
+call sequence; for example, if one added a suitable definition of `showarg`
+for `SubArray` (see `?showarg`), one might obtain the following:
+
+```jl
+a = rand(3,5,7)
+v = view(a, :, 3, 2:5)
+c = reshape(v, 4, 3)
+
+julia> summary(c)
+"4×3 reshape(view(::Array{Float64,3}, Colon(), 3, 2:5), (4,3)) with element type Float64"
+```
+
+which may be someone easier to understand than the default
+
+```jl
+"4×3 Base.ReshapedArray{Float64,2,SubArray{Float64,2,Array{Float64,3},Tuple{Colon,Int64,UnitRange{Int64}},false},Tuple{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64}}}"
+```
+
+You can optionally supply a "complexity threshold" to `summary_build`;
+objects whose types have complexity less than or equal to the
+threshold will be printed using the traditional type-based
+summary. See the documentation for `summary_build` and
+`type_complexity` for more information.
+
+It's worth emphasizing that this package does **not** itself change
+the display of any objects; it simply provides the necessary tools. If
+you're a package author and interested in using ShowItLikeYouBuildIt,
+please keep the following guidelines in mind:
+
+- it is reasonable to customize the printing of objects whose types are
+  defined in your package.
+
+- be wary about changing the display of types defined in `Base` (as we
+  did above, for the purposes of illustration, with `ReshapedArray`
+  and `SubArray`) or of types defined in other packages. Such changes
+  will affect the printing of *all* such objects, and thus might have
+  unintended consequences.

--- a/src/ShowItLikeYouBuildIt.jl
+++ b/src/ShowItLikeYouBuildIt.jl
@@ -2,29 +2,153 @@ __precompile__()
 
 module ShowItLikeYouBuildIt
 
-export summary_compact, shows_compactly
+export showarg, summary_build, type_complexity
 
-show_complexity(x)            = 1
-show_complexity{T}(::Type{T}) = isempty(T.parameters) ? 1 : sum(show_complexity, T.parameters)+1
+"""
+    type_complexity(T::Type) -> c
 
-shows_compactly{T}(::Type{T})  = show_complexity(T) <= length(T.parameters)+1
+Return an integer `c` representing a measure of the "complexity" of
+type `T`. For unnested types, `c = n+1` where `n` is the number of
+parameters in type `T`. However, `type_complexity` calls itself
+recursively on the parameters, so if the parameters have their own
+parameters then the complexity of the type will be (potentially much)
+higher than this.
 
-showtypeof(io::IO, x)                = show(io, typeof(x))
-showtypeof{T}(io::IO, ::Type{T})     = show(io, T)
+# Examples
 
-function summary_compact(io::IO, A::AbstractArray)
-    shows_compactly(typeof(A)) && return print(io, summary(A))
+    # Array{Float64,2}
+    julia> a = rand(3,5);
+
+    julia> type_complexity(typeof(a))
+    3
+
+    julia> length(typeof(a).parameters)+1
+    3
+
+    # Create an object that has type:
+    #    SubArray{Int64,2,Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}},Tuple{StepRange{Int64,Int64},Colon},false}
+    julia> r = reshape(1:9, 3, 3);
+
+    julia> v = view(r, 1:2:3, :);
+
+    julia> type_complexity(typeof(v))
+    15
+
+    julia> length(typeof(v).parameters)+1
+    6
+
+The second example indicates that the total complexity of `v`'s type
+is considerably higher than the complexity of just its "outer"
+SubArray type.
+"""
+type_complexity{T}(::Type{T}) = isempty(T.parameters) ? 1 : sum(type_complexity, T.parameters)+1
+type_complexity(x)            = 1
+
+# Fallback definitions
+"""
+    showarg(stream::IO, x)
+
+Show `x` as if it were an argument to a function. This function is
+used in the printing of "type summaries" in terms of sequences of
+function calls on objects.
+
+The fallback definition is to print `x` as `::\$(typeof(x))`,
+representing argument `x` in terms of its type. However, you can
+specialize this function for specific types to customize printing.
+
+# Example
+
+A SubArray created as `view(a, :, 3, 2:5)`, where `a` is a
+3-dimensional Float64 array, has type
+
+    SubArray{Float64,2,Array{Float64,3},Tuple{Colon,Int64,UnitRange{Int64}},false}
+
+and this type will be printed in the summary. To change the printing of this object to
+
+    view(::Array{Float64,3}, Colon(), 3, 2:5)
+
+you could define
+
+    function ShowItLikeYouBuildIt.showarg(io::IO, v::SubArray)
+        print(io, "view(")
+        showarg(io, parent(v))
+        print(io, ", ", join(v.indexes, ", "))
+        print(io, ')')
+    end
+
+Note that we're calling `showarg` recursively for the parent array
+type.  Printing the parent as `::Array{Float64,3}` is the fallback
+behavior, assuming no specialized method for `Array` has been defined.
+More generally, this would display as
+
+    view(<a>, Colon(), 3, 2:5)
+
+where `<a>` is the output of `showarg` for `a`.
+
+This printing might be activated any time `v` is a field in some other
+container, or if you specialize `Base.summary` for `SubArray` to call
+`summary_build`.
+
+See also: summary_build.
+"""
+showarg{T}(io::IO, ::Type{T}) = print(io, "::Type{", T, "}")
+showarg(io::IO, x) = print(io, "::", typeof(x))
+
+function summary_build(io::IO, A::AbstractArray, cthresh=default_cthresh(A))
+    type_complexity(typeof(A)) <= cthresh && return show_summary_type(io, A)
     print(io, dimstring(indices(A)), ' ')
-    showtypeof(io, A)
+    showarg(io, A)
     print(io, " with element type ", eltype(A))
 end
-function summary_compact(A::AbstractArray)
+
+"""
+    summary_build(A::AbstractArray, [cthresh])
+
+Return a string representing `A` in terms of the sequence of function
+calls that might be used to create `A`, along with information about
+`A`'s size or indices and element type. This function should never be
+called directly, but instead used to specialize `Base.summary` for
+specific `AbstractArray` subtypes. For example, if you want to change
+the summary of SubArray, you might define
+
+    Base.summary(v::SubArray) = summary_build(v)
+
+This function goes hand-in-hand with `showarg`. If you have defined a
+`showarg` method for `SubArray` as in the documentation for `showarg`,
+then the summary of a SubArray might look like this:
+
+    3×4 view(::Array{Float64,3}, :, 3, 2:5) with element type Float64
+
+instead of this:
+
+    3×4 SubArray{Float64,2,Array{Float64,3},Tuple{Colon,Int64,UnitRange{Int64}},false}
+
+The optional argument `cthresh` is a "complexity threshold"; objects
+with type descriptions that are less complex than the specified
+threshold will be printed using the traditional type-based
+summary. The default value is `n+1`, where `n` is the number of
+parameters in `typeof(A)`.  The complexity is calculated with
+`type_complexity`. You can choose a `cthresh` of 0 if you want to
+ensure that your `showarg` version is always used.
+
+See also: showarg, type_complexity.
+"""
+function summary_build(A::AbstractArray, cthresh=default_cthresh(A))
     io = IOBuffer()
-    summary_compact(io, A)
+    summary_build(io, A, cthresh)
     String(io)
 end
 
+# This is effectively the "original summary" as defined in Base. We
+# can't just use that function directly because `summary_build`
+# should only be called by `summary` method that has been specialized
+# for the type, so `summary` isn't available as a fallback.
+show_summary_type(io::IO, A::AbstractArray) = print(io, dimstring(indices(A)), ' ', typeof(A))
+
 dimstring(inds) = Base.inds2string(inds)
 dimstring(inds::Tuple{Vararg{Base.OneTo}}) = Base.dims2string(map(length, inds))
+
+default_cthresh(x) = default_cthresh(typeof(x))
+default_cthresh{T}(::Type{T}) = length(T.parameters)+1
 
 end # module

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+OffsetArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ShowItLikeYouBuildIt
+using ShowItLikeYouBuildIt, OffsetArrays
 using Base.Test
 
 for T in (Float64, Bool, Int8, UInt16, Symbol, String)
@@ -9,6 +9,13 @@ end
 @test type_complexity(Array{Array{Complex{Float32},1},2}) == 6
 
 @test ShowItLikeYouBuildIt.dimstring(()) == "0-dimensional"
+
+io = IOBuffer()
+showarg(io, 3.0)
+@test takebuf_string(io) == "::Float64"
+showarg(io, Float64)
+@test takebuf_string(io) == "::Type{Float64}"
+
 
 # Display of objects
 
@@ -51,4 +58,14 @@ a = reshape(1:24, 3, 4, 2)
 b = Base.PermutedDimsArrays.PermutedDimsArray(a, (2,3,1))
 str = summary(b)
 intstr = string("Int", Sys.WORD_SIZE)
-@test startswith(str, "4×2×3 permuteddimsview(reshape(::UnitRange{$intstr}, (3,4,2)), (2,3,1)) with element type $intstr")
+@test str == "4×2×3 permuteddimsview(reshape(::UnitRange{$intstr}, (3,4,2)), (2,3,1)) with element type $intstr"
+
+o = OffsetArray(rand(3,5), -1:1, -2:2)
+vo = view(o, -1:2:1, :)
+@test summary(vo) == "Base.OneTo(2)×-2:2 view(::OffsetArrays.OffsetArray{Float64,2,Array{Float64,2}}, -1:2:1, Colon()) with element type Float64"
+
+
+Base.summary(A::SubArray) = summary_build(A,1000)
+@test summary(v) == "3×4 SubArray{Float64,2,Array{Float64,3},Tuple{Colon,Int64,UnitRange{Int64}},false}"
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,42 +1,51 @@
 using ShowItLikeYouBuildIt
-using Compat # for redirection of I/O
 using Base.Test
 
 for T in (Float64, Bool, Int8, UInt16, Symbol, String)
-    @test shows_compactly(T)
+    @test type_complexity(T) == 1
 end
+@test type_complexity(Array{Int,2}) == 3
+@test type_complexity(Array{Complex{Float32},2}) == 4
+@test type_complexity(Array{Array{Complex{Float32},1},2}) == 6
 
 @test ShowItLikeYouBuildIt.dimstring(()) == "0-dimensional"
 
-# Test the display of an actual object.
-# Note that this alters how ReshapedArrays and PermutedDimsArrays are displayed; if you
-# care, beware running this in anything other than a "throwaway" julia session.
+# Display of objects
 
-function ShowItLikeYouBuildIt.showtypeof{T,N,perm}(io::IO, A::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm})
-    P = parent(A)
+# Note that these next tests alter how SubArrays, ReshapedArrays, and
+# PermutedDimsArrays are displayed; it's probably best to run this
+# only in a "throwaway" julia session.
+
+function ShowItLikeYouBuildIt.showarg(io::IO, v::SubArray)
+    print(io, "view(")
+    showarg(io, parent(v))
+    print(io, ", ", join(v.indexes, ", "))
+    print(io, ')')
+end
+
+function ShowItLikeYouBuildIt.showarg{T,N,perm}(io::IO, A::Base.PermutedDimsArrays.PermutedDimsArray{T,N,perm})
     print(io, "permuteddimsview(")
-    if ShowItLikeYouBuildIt.shows_compactly(typeof(P))
-	print(io, "::", typeof(P))
-    else
-	ShowItLikeYouBuildIt.showtypeof(io, P)
-    end
+    showarg(io, parent(A))
     print(io, ", ", perm, ')')
 end
 
-Base.summary(A::Base.PermutedDimsArrays.PermutedDimsArray) = summary_compact(A)
-
-function ShowItLikeYouBuildIt.showtypeof(io::IO, A::Base.ReshapedArray)
-    P = parent(A)
+function ShowItLikeYouBuildIt.showarg(io::IO, A::Base.ReshapedArray)
     print(io, "reshape(")
-    if ShowItLikeYouBuildIt.shows_compactly(typeof(P))
-	print(io, "::", typeof(P))
-    else
-	ShowItLikeYouBuildIt.showtypeof(io, P)
-    end
+    showarg(io, parent(A))
     print(io, ", ", A.dims, ')')
 end
 
-Base.summary(A::Base.ReshapedArray) = summary_compact(A)
+Base.summary(A::SubArray) = summary_build(A)
+Base.summary(A::Base.PermutedDimsArrays.PermutedDimsArray) = summary_build(A)
+Base.summary(A::Base.ReshapedArray) = summary_build(A)
+
+a = rand(3,5,7)
+v = view(a, :, 3, 2:5)
+@test summary(v) == "3×4 view(::Array{Float64,3}, Colon(), 3, 2:5) with element type Float64"
+
+c = reshape(v, 4, 3)
+str = summary(c)
+@test str == "4×3 reshape(view(::Array{Float64,3}, Colon(), 3, 2:5), (4,3)) with element type Float64"
 
 a = reshape(1:24, 3, 4, 2)
 b = Base.PermutedDimsArrays.PermutedDimsArray(a, (2,3,1))


### PR DESCRIPTION
Usage in ImageCore revealed that the API was more complicated than necessary, and that the original names I picked were a little misleading. The latter made it hard to reason about what should and should not happen. In addition to being a rewrite, this adds a lot of documentation. The amount of documentation is almost comical in comparison to the amount of code in this repository:

lines of code: 24
lines of docstrings, comments: 120
comments, docstrings, +README: 230

Nearly a factor of 10!
